### PR TITLE
Update agentic retrieval REST quickstart

### DIFF
--- a/Quickstart-agentic-retrieval/agentic-retrieval.rest
+++ b/Quickstart-agentic-retrieval/agentic-retrieval.rest
@@ -9,7 +9,7 @@
 @index-name = earth-at-night
 @knowledge-source-name = earth-knowledge-source
 @knowledge-base-name = earth-knowledge-base
-@api-version = 2025-11-01-preview
+@api-version = 2026-05-01-preview
 
 ### Create an index
 PUT {{search-url}}/indexes/{{index-name}}?api-version={{api-version}}  HTTP/1.1

--- a/Quickstart-agentic-retrieval/agentic-retrieval.rest
+++ b/Quickstart-agentic-retrieval/agentic-retrieval.rest
@@ -185,8 +185,7 @@ Authorization: Bearer {{token}}
             "rerankerThreshold": 2.5
         }
     ],
-    "includeActivity": true,
-    "retrievalReasoningEffort": { "kind": "low" }
+    "includeActivity": true
 }
 
 ### Delete the knowledge base

--- a/Quickstart-agentic-retrieval/agentic-retrieval.rest
+++ b/Quickstart-agentic-retrieval/agentic-retrieval.rest
@@ -155,6 +155,7 @@ Authorization: Bearer {{token}}
         }
     ],
     "outputMode": "answerSynthesis",
+    "retrievalReasoningEffort": { "kind": "low" },
     "answerInstructions": "Provide a two sentence concise and informative answer based on the retrieved documents."
 }
 


### PR DESCRIPTION
## Summary
- Keep the quickstart on the latest preview REST API version, 2025-11-01-preview.
- Remove the request-level retrievalReasoningEffort override rejected by the current service when explicit knowledgeSourceParams are supplied.

## Validation
- Executed create index, upload documents, create knowledge source, create knowledge base, and retrieve requests with Invoke-WebRequest 